### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: 🧪 Cinema Tickets CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/daniellemclaren/project-popcorn/security/code-scanning/1](https://github.com/daniellemclaren/project-popcorn/security/code-scanning/1)

To address this issue, we will explicitly set the `permissions` key at the root level of the workflow. Based on the workflow's steps, no write access seems necessary, so we will limit permissions to `contents: read`. This adheres to the principle of least privilege, ensuring the `GITHUB_TOKEN` has only the access required to complete the job.

- Add the `permissions` block to the root of the workflow file, above the `jobs` key.
- Set `contents: read`, which is sufficient for tasks like checking out the repository and reading files during build and test steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
